### PR TITLE
Changed `zip` dependency to `zippy`

### DIFF
--- a/odsreader.nimble
+++ b/odsreader.nimble
@@ -1,7 +1,7 @@
 # Package
 
 backend       = "c"
-version       = "0.1.0"
+version       = "0.4.0"
 author        = "Dario Lah"
 description   = "OpenDocument Spreadhseet reader"
 license       = "MIT"
@@ -11,6 +11,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.6.0"
+requires "zippy >= 0.10.0"
 
 task test, "Runs the test suite":
   exec "nim c -r tests/test_load_ods"

--- a/src/odsreader.nim
+++ b/src/odsreader.nim
@@ -1,6 +1,6 @@
 ## This module loads OpenDocument Spreadsheet
 
-import zip/zipfiles
+import zippy/ziparchives
 import streams
 import strutils
 import std/parsexml
@@ -20,13 +20,14 @@ proc loadOdsAsTable*(filename: string, sheetName: Option[string]=none(string), o
   ## If *onlyFirstSheet* is set to true, only first sheet wil be loaded. *sheetName* arg has precedence.
   ## Default: load all sheets
 
-  var z: ZipArchive
-  if not z.open(filename, fmRead):
-    echo &"loadOdsAsSeq: failed to open {filename}"
-    quit(1)
+  var z: ZipArchiveReader
+  let z = try: openZipArchive(filename)
+          except:
+            echo &"loadOdsAsSeq: failed to open {filename}"
+            quit(1)
 
   let outStream = newStringStream("")
-  z.extractFile("content.xml", outStream)
+  outStream.write(z.extractFile("content.xml"))
   outStream.setPosition(0)
 
   var x: XmlParser

--- a/src/odsreader.nim
+++ b/src/odsreader.nim
@@ -20,7 +20,6 @@ proc loadOdsAsTable*(filename: string, sheetName: Option[string]=none(string), o
   ## If *onlyFirstSheet* is set to true, only first sheet wil be loaded. *sheetName* arg has precedence.
   ## Default: load all sheets
 
-  var z: ZipArchiveReader
   let z = try: openZipArchive(filename)
           except:
             echo &"loadOdsAsSeq: failed to open {filename}"


### PR DESCRIPTION
This PR solves #1 issue by changing C-based `zip` dependency that is currently broken on Windows (and it seems unlikely to be fixed soon given the issue sits for years unsolved) to pure Nim `zippy` dependency.

In addition to small code rewire, I've also added dependency to .nimble file, so it is downloaded through Nimble automatically during `odsreader` installation (current version lacked that for `zip` library which yielded error if someone haven't had it installed) and also changed version to 0.4.0, so Nimble can recognise version correctly - I made it so you can publish new version and have it all sorted.

**Note**: I haven't made extensive tests on this version of the library. It works on my Windows 10 machine correctly, but I think it should get better test whether it works on Linux and if all procedures are correct in edge cases or something. I'm not experienced programmer sadly, so that's I think as much as I can help to make this lib work on Windows machine. Please let me know if I could do something to make this PR go through though!